### PR TITLE
Fix using command line args on installed Brist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install:
 	cat <<- EOF > $(DESTDIR)$(bindir)/check-bridge
 		#!/bin/sh
 		cd $(libdir)
-		exec ./brist.sh
+		exec ./brist.sh "\$$@"
 	EOF
 	chmod 0755 $(DESTDIR)$(bindir)/check-bridge
 	for file in $(DOCS); do						\


### PR DESCRIPTION
Command line args needs to be passed to the script that
starts Brist when installed. So you can do
`check-bridge -t topology`.  The variable $@ needs to
be escaped twice, once for Make and once again when
writing to the script file.

A similar issue happens with `make check -t topology`, but in that case it is Make that tries to interpret the arguments. Not sure if we can get around that in a nice way. The solution could probably be something like `args="-t topology"`.