### PR TITLE
mrouter_host: Add test

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -415,3 +415,38 @@ brport_has()
 {
     bridge link help 2>&1 | grep -q $1
 }
+
+br_test()
+{
+    local port="$1"
+    local setting="$2"
+    local val="$3"
+    local cmd=bridge
+    local altval=
+
+    # There are some inconsistencies in the output from iproute2 with
+    # regards to boolean values - we try to paper over those here.
+    case $val in
+	on)
+	    altval=1
+	    ;;
+	off)
+	    altval=0
+	    ;;
+	1)
+	    altval=on
+	    ;;
+	0)
+	    altval=off
+	    ;;
+    esac
+
+    if stat /sys/class/net/$port/bridge >/dev/null 2>&1; then
+	cmd=ip
+    fi
+
+    $cmd -d link show dev $port | grep -q "$setting $val" && return 0
+
+    [ "$altval" ] && \
+	$cmd -d link show dev $port | grep -q "$setting $altval"
+}

--- a/lib.sh
+++ b/lib.sh
@@ -300,7 +300,25 @@ report()
 # Inject IGMP v2 query frames on interface $1
 mcast_query_start()
 {
-    nemesis igmp -d "$1" -p 0x11 -r 100 -c 100 -D 224.0.0.1 -i 10 &
+    local count=100
+    local ival=10
+
+    while getopts "c:i:" opt; do
+	case $opt in
+	    c)
+		count=$OPTARG
+		;;
+	    i)
+		ival=$OPTARG
+		;;
+	    *)
+		exit 1
+		;;
+	esac
+    done
+    shift $((OPTIND - 1))
+
+    nemesis igmp -d "$1" -p 0x11 -r 100 -c $count -D 224.0.0.1 -i $ival &
     eval "${1}_query=$!"
 }
 

--- a/lib.sh
+++ b/lib.sh
@@ -406,3 +406,12 @@ create_br()
     done
 }
 
+br_has()
+{
+    ip link add type bridge help 2>&1 | grep -q $1
+}
+
+brport_has()
+{
+    bridge link help 2>&1 | grep -q $1
+}

--- a/suite/40-mrouter.sh
+++ b/suite/40-mrouter.sh
@@ -1,180 +1,299 @@
 # shellcheck disable=SC2154 disable=SC2046 disable=SC2086
 
-ip4_src=169.254.255.254
-ip6_src=2001:dead::1
+mrouter_ip4_src=169.254.255.254
+mrouter_ip6_src=2001:dead::1
 
-ip4_grp()
+mrouter_ip4_grp()
 {
     printf 239.255.0.$1
 }
 
-ip6_grp()
+mrouter_ip6_grp()
 {
     printf ff02::ff0$1
 }
 
-mac_grp()
+mrouter_mac_grp()
 {
     printf 01:00:00:00:00:0$1
 }
 
-register()
+mrouter_register()
 {
-    bridge mdb add dev $br0 port $1 grp $(ip4_grp $2) permanent
-    bridge mdb add dev $br0 port $1 grp $(ip6_grp $2) permanent
-    bridge mdb add dev $br0 port $1 grp $(mac_grp $2) permanent
+    local permanent=$([ $1 = $br0 ] || echo permanent)
+
+    bridge mdb add dev $br0 port $1 grp $(mrouter_ip4_grp $2) $permanent
+    bridge mdb add dev $br0 port $1 grp $(mrouter_ip6_grp $2) $permanent
+    bridge mdb add dev $br0 port $1 grp $(mrouter_mac_grp $2)  permanent
 }
 
-unregister()
+mrouter_unregister()
 {
-    bridge mdb del dev $br0 port $1 grp $(ip4_grp $2) permanent
-    bridge mdb del dev $br0 port $1 grp $(ip6_grp $2) permanent
-    bridge mdb del dev $br0 port $1 grp $(mac_grp $2) permanent
+    bridge mdb del dev $br0 port $1 grp $(mrouter_ip4_grp $2)
+    bridge mdb del dev $br0 port $1 grp $(mrouter_ip6_grp $2)
+    bridge mdb del dev $br0 port $1 grp $(mrouter_mac_grp $2)
 }
 
-
-mrouter_report_one()
+mrouter_mcast_set()
 {
-    local port=$1
-    local mrouter="$2"
-    local reg_grps="$3"
-    local all_grps="$4"
+    if [ $1 = $br0 ]; then
+	local flood=$([ $2 = on ] && echo 1 || echo 0)
 
-    for g in $all_grps; do
-	if echo $reg_grps | grep -q $g; then
-	    step "  Verify that $port received group $g (MAC)"
-	    report $port | grep -q "> $(mac_grp $g)" || return 1
-	else
-	    step "  Verify that $port didn't receive group $g (MAC)"
-	    if report $port | grep -q "> $(mac_grp $g)"; then
-		if [ "$mrouter" = "yes" ]; then
-		    # There's lots of hardware without separate controls for
-		    # flooding of IP and non-IP multicast, so settle for a
-		    # warning here.
-		    warn "$port does not discriminate IP from non-IP multicast"
-		else
-		    return 1
+	ip link set dev $1 type bridge mcast_flood $flood mcast_router $3
+    else
+	bridge link set dev $1 mcast_flood $2 mcast_router $3
+    fi
+}
+
+mdb_is_member()
+{
+    bridge mdb show dev $br0 | grep -q "port $1 grp $2"
+}
+
+mdb_is_registered()
+{
+    bridge mdb show dev $br0 | grep -q "grp $1"
+}
+
+mrouter_report_proto()
+{
+    local h=$1
+    local b=$2
+    local proto=$3
+    local mrouter=$(br_test $b mcast_router 2 && echo yes || echo no)
+    local mcast_flood=$(br_test $b mcast_flood on && echo yes || echo no)
+
+    for g in 1 2 3 4; do
+	local grp=
+	case $proto in
+	    mac)
+		grp=$(mrouter_mac_grp $g)
+		;;
+	    ip4)
+		grp=$(mrouter_ip4_grp $g)
+		;;
+	    ip6)
+		grp=$(mrouter_ip6_grp $g)
+		;;
+	esac
+
+	local registered="$(mdb_is_registered $grp && echo yes || echo no)"
+	local member="$(mdb_is_member $b $grp && echo yes || echo no)"
+
+	local rx=
+	case $proto in
+	    mac)
+		rx=$(report $h | grep -q "> $grp" \
+			 && echo yes || echo no)
+		;;
+	    ip4)
+		rx=$(report $h | grep -q "$grp: ICMP echo request" \
+			 && echo yes || echo no)
+		;;
+	    ip6)
+		rx=$(report $h | grep -q "> $grp: ICMP6, echo request" \
+			 && echo yes || echo no)
+		;;
+	esac
+
+	# First, verify that we receive all registered and/or flooded
+	# groups - these are nonnegotiable.
+	case $proto in
+	    mac)
+		if [ $member = yes ] || [ $registered = no -a $mcast_flood = yes ]; then
+		    step "  Verify that $h received group $grp"
+		    [ $rx = yes ] && continue || return 1
 		fi
-	    fi
-	fi
-    done
+		;;
+	    ip*)
+		if [ $member = yes -o $mrouter = yes ]; then
+		    step "  Verify that $h received group $grp"
+		    [ $rx = yes ] && continue || return 1
+		fi
+		;;
+	esac
 
-    for g in $all_grps; do
-	if [ "$mrouter" = "yes" ] || echo $reg_grps | grep -q $g; then
-	    step "  Verify that $port received group $g (IPv4/6)"
-	    report $port | grep -q "$(ip4_grp $g): ICMP echo request" || return 1
-	    report $port | grep -q "$(ip6_grp $g): ICMP6, echo request" || return 1
-	else
-	    step "  Verify that $port didn't receive group $g (IPv4/6)"
-	    report $port | grep -q "$(ip4_grp $g): ICMP echo request" && return 1
-	    report $port | grep -q "$(ip6_grp $g): ICMP6, echo request" && return 1
-	fi
+	# Nothing more is expected, so if the current group was not
+	# received, then we are done.
+	step "  Verify that $h did not receive group $grp"
+	[ $rx = no ] && continue
+
+	# We received something we did not expect. This can happen
+	# because the underlying hardware is not able to separately
+	# control flooding of IP and non-IP multicast; settle for a
+	# warning in these cases.
+	case $proto in
+	    mac)
+		[ $mrouter = yes ] || return 1
+		;;
+	    ip*)
+		[ $mcast_flood = yes ] || return 1
+		;;
+	esac
+
+	warn "$b does not discriminate IP from non-IP multicast"
     done
 
     true
 }
 
-mrouter_inject_and_report()
+mrouter_report_port()
 {
-    local all_grps="$1"
-    local b2_grps="$2"
-    local b3_grps="$3"
-    local b3_mrouter=$4
+    local h=$1
+    local b=$2
 
-    capture -f "icmp or icmp6 or ether proto 0xbbbb" $h2 $h3
+    mrouter_report_proto $h $b mac || return 1
+    mrouter_report_proto $h $b ip4 || return 1
 
-    step "  Inject MAC/IPv4/IPv6 multicast to all groups ($all_grps) on $h1"
-    for g in $all_grps; do
-	eth -g $g | { cat; echo U from $h1; } | inject $h1
-	mcast_gen -c 1 -g $(ip4_grp $g) $ip4_src
-	mcast_gen -c 1 -g $(ip6_grp $g)%$h1 $ip6_src
-    done
+    # TODO: No IPv6 support in the host test, see below
+    if [ $mode = host ]; then
+	return
+    fi
 
-    mrouter_report_one $h2 no "$b2_grps" "$all_grps" || return 1
-    mrouter_report_one $h3 $b3_mrouter "$b3_grps" "$all_grps" || return 1
+    mrouter_report_proto $h $b ip6 || return 1
 }
 
-mrouter_port()
+mrouter_inject_and_report()
+{
+    capture -f "icmp or icmp6 or ether proto 0xbbbb" $oh $rh
+
+    step "  Inject MAC/IP multicast to all groups on $ih"
+    for g in 1 2 3 4; do
+	eth -g $g | { cat; echo U from $ih; } | inject $ih
+	mcast_gen -c 1 -g $(mrouter_ip4_grp $g) $mrouter_ip4_src
+
+	# TODO: Nemesis can't yet generate MLD queries, so we only
+	# test IPv6 for the port version of the test, i.e. when the
+	# bridge is generating queries internally.
+	if [ $mode = port ]; then
+	    mcast_gen -c 1 -g $(mrouter_ip6_grp $g)%$ih $mrouter_ip6_src
+	fi
+    done
+    sleep 1
+
+    mrouter_report_port $oh $ob || return 1
+    mrouter_report_port $rh $rb || return 1
+}
+
+mrouter_test()
 {
     require3loops
 
-    local in=$b1
-    local out=$b2
-    local rport=$b3
+    if ! brport_has mcast_router; then
+        step "Mcast router port feature not supported, skipping."
+        skip
+    fi
+
+    mode=$1
+
+    # Local port names:
+    #
+    # b/h suffix refers to either the (b)ridge or the (h)ost side of
+    # the loop.
+    #
+    # - (i)nput:   Where packets are injected
+    # - (o)utput:  Non-router reference port
+    # - (q)uerier: Where queries are generated/injected
+    # - (r)outer:  Port under test
+    #
+    ib=$b1
+    ih=$h1
+    ob=$b2
+    oh=$h2
+    qb=$([ $mode = host ] && echo $b3 || echo $br0)
+    qh=$([ $mode = host ] && echo $h3)
+    rb=$([ $mode = port ] && echo $b3 || echo $br0)
+    rh=$([ $mode = port ] && echo $h3 || echo $br0)
 
     local bropts="mcast_snooping 1"
     bropts="$bropts mcast_query_interval 100"
     bropts="$bropts mcast_startup_query_interval 100"
     bropts="$bropts mcast_query_response_interval 100"
 
-    create_br $br0 "$bropts" $in $out $rport
+    create_br $br0 "$bropts" $b1 $b2 $b3
 
-    if ! bridge -d link show | grep -q " mcast_router"; then
-        step "Mcast router port feature not supported, skipping."
-        skip
+    ip addr add ${mrouter_ip4_src}/16 dev $ih
+    ip addr add ${mrouter_ip6_src}/64 dev $ih
+
+    mrouter_mcast_set $ob off 0
+    mrouter_mcast_set $rb off 0
+
+    if [ $mode = host ]; then
+	mcast_query_start -c 1000 -i 1 $qh
+    else
+	ip link set dev $br0 type bridge mcast_querier 1
     fi
+    step "Wait for $qb to assume the role of querier"
+    sleep $([ $mode = host ] && echo 10 || echo 2)
 
-    ip addr add ${ip4_src}/16 dev $h1
-    ip addr add ${ip6_src}/64 dev $h1
+    step "Register groups 2 and 3 on $ob"
+    mrouter_register $ob 2
+    mrouter_register $ob 3
+    mrouter_inject_and_report || fail
 
-    bridge link set dev $out mcast_flood off mcast_router 0
-    bridge link set dev $rport mcast_flood off mcast_router 0
+    step "Configure $rb as a multicast router port"
+    mrouter_mcast_set $rb off 2
+    mrouter_inject_and_report || fail
 
-    ip link set dev $br0 type bridge mcast_querier 1
-    step "Wait for $br0 to assume the role of querier"
-    sleep 2
+    step "Register group 4 on $ob"
+    mrouter_register $ob 4
+    mrouter_inject_and_report || fail
 
-    step "Register groups 2 and 3 on $out"
-    register $out 2
-    register $out 3
-    mrouter_inject_and_report "1 2 3" "2 3" "" no || fail
-
-    step "Configure $rport as a multicast router port"
-    bridge link set dev $rport mcast_router 2
-    mrouter_inject_and_report "1 2 3" "2 3" "" yes || fail
-
-    step "Register group 4 on $out"
-    register $out 4
-    mrouter_inject_and_report "1 2 3 4" "2 3 4" "" yes || fail
-
-    step "Remove previously registered group 2 from $out"
-    unregister $out 2
-    mrouter_inject_and_report "1 2 3 4" "3 4" "" yes || fail
+    step "Remove previously registered group 2 from $ob"
+    mrouter_unregister $ob 2
+    mrouter_inject_and_report || fail
 
 
-    step "Remove all groups from $out, register groups 2 and 3 on $rport"
-    unregister $out 3
-    unregister $out 4
-    register $rport 2
-    register $rport 3
-    mrouter_inject_and_report "1 2 3 4" "" "2 3" yes || fail
+    step "Remove all groups from $ob, register groups 2 and 3 on $rb"
+    mrouter_unregister $ob 3
+    mrouter_unregister $ob 4
+    mrouter_register $rb 2
+    mrouter_register $rb 3
+    mrouter_inject_and_report || fail
 
-    step "Unset ${rport}'s multicast router port configuration, enable flooding on $out"
-    bridge link set dev $rport mcast_router 0
-    bridge link set dev $out mcast_flood on
-    mrouter_inject_and_report "1 2 3 4" "1 4" "2 3" no || fail
+    step "Unset ${rb}'s multicast router port configuration, enable flooding on $ob"
+    mrouter_mcast_set $rb off 0
+    mrouter_mcast_set $ob on 0
 
-    step "Register group 4 on $rport"
-    register $rport 4
-    mrouter_inject_and_report "1 2 3 4" "1" "2 3 4" no || fail
+    mrouter_inject_and_report || fail
 
-    step "Configure $rport as a multicast router port"
-    bridge link set dev $rport mcast_router 2
-    mrouter_inject_and_report "1 2 3 4" "1" "2 3 4" yes || fail
+    step "Register group 4 on $rb"
+    mrouter_register $rb 4
+    mrouter_inject_and_report || fail
 
-    step "Remove previously registered group 4 on $rport"
-    unregister $rport 4
-    mrouter_inject_and_report "1 2 3 4" "1 4" "2 3" yes || fail
+    step "Configure $rb as a multicast router port"
+    mrouter_mcast_set $rb off 2
 
-    step "Remove previously registered groups 2 and 3 on $rport"
-    unregister $rport 2
-    unregister $rport 3
-    mrouter_inject_and_report "1 2 3 4" "1 2 3 4" "" yes || fail
+    mrouter_inject_and_report || fail
 
-    step "Unset ${rport}'s multicast router port configuration"
-    bridge link set dev $rport mcast_router 0
-    mrouter_inject_and_report "1 2 3 4" "1 2 3 4" "" no || fail
+    step "Remove previously registered group 4 on $rb"
+    mrouter_unregister $rb 4
+    mrouter_inject_and_report || fail
+
+    step "Remove previously registered groups 2 and 3 on $rb"
+    mrouter_unregister $rb 2
+    mrouter_unregister $rb 3
+    mrouter_inject_and_report || fail
+
+    step "Unset ${rb}'s multicast router port configuration"
+    mrouter_mcast_set $rb off 0
+    mrouter_inject_and_report || fail
+
+    if [ $mode = host ]; then
+	mcast_query_stop $qh
+    fi
 
     pass
 }
+
+mrouter_port()
+{
+    mrouter_test port
+}
 alltests="$alltests mrouter_port"
+
+mrouter_host()
+{
+    mrouter_test host
+}
+alltests="$alltests mrouter_host"


### PR DESCRIPTION
Generalize the existing mrouter_port test, such that the router port can be either a bridge port, or the bridge itself.

This means we have to deal with all the nasty inconsistencies of allowed flags for MDB entries etc. It also means that while we can use the bridge's internal querier function for the port test, we must generate our own queries when the querier is placed behind a bridge port. For this reason, the host test requires that nemesis is available on the test system.